### PR TITLE
Use meta-merge instead of merge

### DIFF
--- a/src/duct/router/reitit.clj
+++ b/src/duct/router/reitit.clj
@@ -2,6 +2,7 @@
   (:require [reitit.ring :as ring]
             [reitit.ring.coercion :as ring.coercion]
             [reitit.coercion.spec :as coercion.spec]
+            [duct.core.merge :refer [meta-merge]]
             [duct.core.resource]
             [integrant.core :as ig]
             [clojure.walk :as walk]))
@@ -25,7 +26,7 @@
 (defmethod ig/prep-key :duct.router/reitit [_ {:keys [routes]
                                                ::ring/keys [opts default-handlers]}]
   {:routes (walk/postwalk resolve-symbol routes)
-   ::ring/opts (merge {:data default-route-opts} opts)
+   ::ring/opts (meta-merge {:data default-route-opts} opts)
    ::ring/default-handlers (merge default-default-handlers default-handlers)})
 
 (defmethod ig/init-key :duct.router/reitit [_ {:keys [routes]


### PR DESCRIPTION
(merge {:data {:some "data"}} {:data {:more "data"}})
;; => {:data {:more "data"}}

(meta-merge {:data {:some "data"}} {:data {:more "data"}})
;; => {:data {:some "data", :more "data"}}