### PR TITLE
Add :reitit.ring/extra-handlers option and redirect-trailing-slash ha…

### DIFF
--- a/src/duct/router/reitit.clj
+++ b/src/duct/router/reitit.clj
@@ -24,14 +24,14 @@
 
 (defmethod ig/prep-key :duct.router/reitit
   [_ {:keys [routes]
-      ::ring/keys [opts default-handlers extra-handlers]}]
+      ::ring/keys [opts default-handlers handlers]}]
   {:routes (walk/postwalk resolve-symbol routes)
    ::ring/opts (merge {:data default-route-opts} opts)
-   ::ring/extra-handlers extra-handlers
+   ::ring/handlers handlers
    ::ring/default-handlers (merge default-default-handlers default-handlers)})
 
 (defmethod ig/init-key :duct.router/reitit
-  [_ {:keys [routes] ::ring/keys [opts default-handlers extra-handlers]}]
+  [_ {:keys [routes] ::ring/keys [opts default-handlers handlers]}]
   (ring/ring-handler
    (ring/router routes opts)
-   (apply ring/routes (conj extra-handlers (ring/create-default-handler default-handlers)))))
+   (apply ring/routes (conj handlers (ring/create-default-handler default-handlers)))))

--- a/src/duct/router/reitit.clj
+++ b/src/duct/router/reitit.clj
@@ -34,6 +34,4 @@
   [_ {:keys [routes] ::ring/keys [opts default-handlers extra-handlers]}]
   (ring/ring-handler
    (ring/router routes opts)
-   (if extra-handlers
-     (apply ring/routes (conj extra-handlers (ring/create-default-handler default-handlers)))
-     (ring/create-default-handler default-handlers))))
+   (apply ring/routes (conj extra-handlers (ring/create-default-handler default-handlers)))))

--- a/src/duct/router/reitit.clj
+++ b/src/duct/router/reitit.clj
@@ -22,14 +22,18 @@
     (var-get var)
     x))
 
-(defmethod ig/prep-key :duct.router/reitit [_ {:keys [routes]
-                                               ::ring/keys [opts default-handlers]}]
+(defmethod ig/prep-key :duct.router/reitit
+  [_ {:keys [routes]
+      ::ring/keys [opts default-handlers extra-handlers]}]
   {:routes (walk/postwalk resolve-symbol routes)
    ::ring/opts (merge {:data default-route-opts} opts)
+   ::ring/extra-handlers extra-handlers
    ::ring/default-handlers (merge default-default-handlers default-handlers)})
 
-(defmethod ig/init-key :duct.router/reitit [_ {:keys [routes]
-                                               ::ring/keys [opts default-handlers]}]
+(defmethod ig/init-key :duct.router/reitit
+  [_ {:keys [routes] ::ring/keys [opts default-handlers extra-handlers]}]
   (ring/ring-handler
    (ring/router routes opts)
-   (ring/create-default-handler default-handlers)))
+   (if extra-handlers
+     (apply ring/routes (conj extra-handlers (ring/create-default-handler default-handlers)))
+     (ring/create-default-handler default-handlers))))

--- a/src/duct/router/reitit/handler.clj
+++ b/src/duct/router/reitit/handler.clj
@@ -1,0 +1,9 @@
+(ns duct.router.reitit.handler
+  (:require
+   [integrant.core :as ig]
+   [reitit.ring :as ring]))
+
+(defmethod ig/init-key :duct.router.reitit.handler/redirect-trailing-slash [_ opts]
+  (if (empty? opts)
+    (ring/redirect-trailing-slash-handler)
+    (ring/redirect-trailing-slash-handler opts)))


### PR DESCRIPTION
This change allows us to add exrta default handlers. This is useful if you'd like to add extra handlers such as `reitit.ring/redirect-trailing-slash-handler` which allows you to add trailing slashes to your url https://cljdoc.org/d/metosin/reitit/0.5.10/doc/ring/slash-handler

```clojure
{:duct.router/reitit
 {:reitit.ring/extra-handlers
  [#ig/ref :duct.router.reitit.handler/redirect-trailing-slash]
  :routes [["/"]]}

 :duct.router.reitit.handler/redirect-trailing-slash {}}
```

Maybe there's a better name for `:reitit.ring/extra-handlers` ?
